### PR TITLE
feat: add optional voter name (non-anonymous ROTI)

### DIFF
--- a/internal/model/database.go
+++ b/internal/model/database.go
@@ -57,6 +57,7 @@ func initTables(db *sql.DB) {
 		"description" TEXT,
 		"hide" INTEGER,
 		"feedback" INTEGER DEFAULT 0,
+		"require_name" INTEGER DEFAULT 0,
         "created_at" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 	  );`
 
@@ -64,7 +65,8 @@ func initTables(db *sql.DB) {
 		"id" TEXT NOT NULL PRIMARY KEY,		
 		"value" INTEGER,
 		"roti" INTEGER,
-		"feedback" TEXT
+		"feedback" TEXT,
+		"voter_name" TEXT
 	  );`
 
 	rotiStatement, err := db.Prepare(createROTITable)
@@ -130,6 +132,34 @@ func addMissingColumns(db *sql.DB) {
 		}
 
 		log.Info().Msg("'created_at' column added to 'roti' table")
+	}
+
+	if !columnExists(db, "roti", "require_name") {
+		addRequireNameToROTITable := `ALTER TABLE roti ADD COLUMN "require_name" INTEGER DEFAULT 0;`
+		dbStatement, err := db.Prepare(addRequireNameToROTITable)
+		if err != nil {
+			log.Fatal().Msg(err.Error())
+		}
+		_, err = dbStatement.Exec()
+		if err != nil {
+			log.Fatal().Msg(err.Error())
+		}
+
+		log.Info().Msg("'require_name' column added to 'roti' table")
+	}
+
+	if !columnExists(db, "vote", "voter_name") {
+		addVoterNameToVoteTable := `ALTER TABLE vote ADD COLUMN "voter_name" TEXT;`
+		dbStatement, err := db.Prepare(addVoterNameToVoteTable)
+		if err != nil {
+			log.Fatal().Msg(err.Error())
+		}
+		_, err = dbStatement.Exec()
+		if err != nil {
+			log.Fatal().Msg(err.Error())
+		}
+
+		log.Info().Msg("'voter_name' column added to 'vote' table")
 	}
 
 	// look for rows that don't have a value for created_at

--- a/internal/model/roti.go
+++ b/internal/model/roti.go
@@ -20,6 +20,7 @@ type ROTIEntity struct {
 	description string
 	hide        bool
 	feedback    bool
+	requireName bool
 }
 
 type ROTIID int
@@ -44,49 +45,50 @@ func NewROTIID() (rotiID ROTIID) {
 	return
 }
 
-func NewROTIEntity(id ROTIID, description string, hide, feedback bool) (roti ROTIEntity) {
+func NewROTIEntity(id ROTIID, description string, hide, feedback, requireName bool) (roti ROTIEntity) {
 	roti.id = id
 	roti.description = description
 	roti.hide = hide
 	roti.feedback = feedback
+	roti.requireName = requireName
 
 	return
 }
 
 func GetROTI(rotiid ROTIID) (roti ROTIEntity, err error) {
 	var description string
-	var hide, feedback bool
+	var hide, feedback, requireName bool
 
-	row, err := sqliteDatabase.Query("SELECT description,hide,feedback FROM roti WHERE rotiid = ?", int(rotiid))
+	row, err := sqliteDatabase.Query("SELECT description,hide,feedback,require_name FROM roti WHERE rotiid = ?", int(rotiid))
 	if err != nil {
 		log.Fatal().Err(err).Msg("")
 	}
 	defer row.Close()
 
 	row.Next()
-	err = row.Scan(&description, &hide, &feedback)
+	err = row.Scan(&description, &hide, &feedback, &requireName)
 	if err != nil {
 		return ROTIEntity{}, err
 	}
-	return NewROTIEntity(rotiid, description, hide, feedback), nil
+	return NewROTIEntity(rotiid, description, hide, feedback, requireName), nil
 }
 
 func insertROTI(db *sql.DB, roti ROTIEntity) {
 	id := int(roti.GetID())
-	log.Info().Msgf("inserting ROTI record %d (%s) hidden:%t feedback:%t", id, roti.description, roti.hide, roti.feedback)
-	insertROTISQL := `INSERT INTO ROTI(rotiid, description, hide, feedback) VALUES (?, ?, ?, ?)`
+	log.Info().Msgf("inserting ROTI record %d (%s) hidden:%t feedback:%t requireName:%t", id, roti.description, roti.hide, roti.feedback, roti.requireName)
+	insertROTISQL := `INSERT INTO ROTI(rotiid, description, hide, feedback, require_name) VALUES (?, ?, ?, ?, ?)`
 	statement, err := db.Prepare(insertROTISQL)
 
 	if err != nil {
 		log.Fatal().Err(err).Msg("")
 	}
-	_, err = statement.Exec(id, roti.description, roti.hide, roti.feedback)
+	_, err = statement.Exec(id, roti.description, roti.hide, roti.feedback, roti.requireName)
 	if err != nil {
 		log.Fatal().Err(err).Msg("")
 	}
 }
 
-func CreateROTI(description string, hide, feedback bool, clean int) (rotiID ROTIID) {
+func CreateROTI(description string, hide, feedback, requireName bool, clean int) (rotiID ROTIID) {
 	// before doing anything, run a check to see if we can clean some old ROTIs
 	log.Info().Msgf("searching for opportunistic cleaning on the ROTI database")
 	cleanOldROTIs(sqliteDatabase, clean)
@@ -109,7 +111,7 @@ func CreateROTI(description string, hide, feedback bool, clean int) (rotiID ROTI
 		panic(ErrNoFreeIDs)
 	}
 
-	insertROTI(sqliteDatabase, NewROTIEntity(rotiID, description, hide, feedback))
+	insertROTI(sqliteDatabase, NewROTIEntity(rotiID, description, hide, feedback, requireName))
 
 	return
 }
@@ -232,12 +234,16 @@ func (currentROTI *ROTIEntity) HasFeedback() bool {
 	return currentROTI.feedback
 }
 
-func (currentROTI *ROTIEntity) AddVoteToROTI(value float64, feedback string) (err error) {
+func (currentROTI *ROTIEntity) RequiresName() bool {
+	return currentROTI.requireName
+}
+
+func (currentROTI *ROTIEntity) AddVoteToROTI(value float64, feedback string, voterName string) (err error) {
 	currentVote, err := NewVoteEntity(value)
 	if err != nil {
 		return fmt.Errorf("%w: %s", ErrInvalidVoteID, err)
 	}
-	insertVote(sqliteDatabase, currentVote, currentROTI.id, feedback)
+	insertVote(sqliteDatabase, currentVote, currentROTI.id, feedback, voterName)
 	return nil
 }
 
@@ -309,18 +315,25 @@ func (currentROTI *ROTIEntity) VotesAverage() float64 {
 
 func (currentROTI *ROTIEntity) ListFeedbacks() (feedbacks []string) {
 	var feedback string
+	var voterName string
 	var value float32
-	row, err := sqliteDatabase.Query("SELECT value, feedback FROM vote WHERE roti = ?", int(currentROTI.id))
+	row, err := sqliteDatabase.Query("SELECT value, feedback, voter_name FROM vote WHERE roti = ?", int(currentROTI.id))
 	if err != nil {
 		log.Fatal().Msgf("couldn't connect to database")
 	}
 	defer row.Close()
 	for row.Next() {
-		if err := row.Scan(&value, &feedback); err != nil {
+		if err := row.Scan(&value, &feedback, &voterName); err != nil {
 			log.Error().Msgf("couldn't scan values : %s", err.Error())
 		}
-		if feedback != "" {
-			feedbacks = append(feedbacks, fmt.Sprintf("(%.1f) %s", value, feedback))
+		if feedback != "" || voterName != "" {
+			if voterName != "" && feedback != "" {
+				feedbacks = append(feedbacks, fmt.Sprintf("(%.1f) %s — %s", value, voterName, feedback))
+			} else if voterName != "" {
+				feedbacks = append(feedbacks, fmt.Sprintf("(%.1f) %s", value, voterName))
+			} else if feedback != "" {
+				feedbacks = append(feedbacks, fmt.Sprintf("(%.1f) %s", value, feedback))
+			}
 		}
 	}
 	return

--- a/internal/model/roti_test.go
+++ b/internal/model/roti_test.go
@@ -35,7 +35,7 @@ func TestGetROTI(t *testing.T) {
 	defer removeData()
 
 	rotidesc := "test"
-	rotiid := CreateROTI(rotidesc, false, false, 30)
+	rotiid := CreateROTI(rotidesc, false, false, false, 30)
 
 	testedRoti, err := GetROTI(rotiid)
 	if err != nil {
@@ -57,8 +57,8 @@ func TestListROTIs(t *testing.T) {
 	InitDatabase()
 	defer removeData()
 
-	rotiid1 := CreateROTI("test1", false, false, 30)
-	rotiid2 := CreateROTI("test2", false, false, 30)
+	rotiid1 := CreateROTI("test1", false, false, false, 30)
+	rotiid2 := CreateROTI("test2", false, false, false, 30)
 
 	rotiList := []ShortROTIInfo{
 		{ID: rotiid2, Desc: "test2"},

--- a/internal/model/vote.go
+++ b/internal/model/vote.go
@@ -17,8 +17,9 @@ var (
 )
 
 type VoteEntity struct {
-	id    VoteID
-	value float64
+	id        VoteID
+	value     float64
+	voterName string
 }
 
 type VoteID string
@@ -35,6 +36,10 @@ func (currentVote *VoteEntity) GetVote() float64 {
 	return currentVote.value
 }
 
+func (currentVote *VoteEntity) GetVoterName() string {
+	return currentVote.voterName
+}
+
 func NewVoteEntity(value float64) (vote VoteEntity, err error) {
 	uuid, err := uuid.NewRandom()
 	if err != nil {
@@ -47,15 +52,15 @@ func NewVoteEntity(value float64) (vote VoteEntity, err error) {
 	return
 }
 
-func insertVote(db *sql.DB, vote VoteEntity, rotiid ROTIID, feedback string) {
+func insertVote(db *sql.DB, vote VoteEntity, rotiid ROTIID, feedback string, voterName string) {
 	log.Info().Msgf("Inserting Vote record %s for ROTI %d", vote.id, int(rotiid))
-	insertVoteSQL := `INSERT INTO vote(id, value, roti, feedback) VALUES (?, ?, ?, ?)`
+	insertVoteSQL := `INSERT INTO vote(id, value, roti, feedback, voter_name) VALUES (?, ?, ?, ?, ?)`
 	statement, err := db.Prepare(insertVoteSQL)
 
 	if err != nil {
 		log.Fatal().Msg(err.Error())
 	}
-	_, err = statement.Exec(vote.id, vote.value, rotiid, feedback)
+	_, err = statement.Exec(vote.id, vote.value, rotiid, feedback, voterName)
 	if err != nil {
 		log.Fatal().Msg(err.Error())
 	}

--- a/internal/model/vote_test.go
+++ b/internal/model/vote_test.go
@@ -33,10 +33,11 @@ func initVoteTest(values []float64, feedbacks []string) (ROTIEntity, error) {
 		description: "test",
 		hide:        false,
 		feedback:    true,
+		requireName: false,
 	}
 
 	for i, value := range values {
-		err := roti.AddVoteToROTI(value, feedbacks[i])
+		err := roti.AddVoteToROTI(value, feedbacks[i], "")
 		if err != nil {
 			return roti, err
 		}

--- a/internal/services/handler.go
+++ b/internal/services/handler.go
@@ -229,12 +229,14 @@ func displayVoteHandler(w http.ResponseWriter, r *http.Request) {
 		VoteStep    string
 		Description string
 		HasFeedback bool
+		RequireName bool
 		Version     string
 	}
 	template.RotiID = strconv.Itoa(rotiID)
 	template.VoteStep = fmt.Sprintf("%f", currentConfig.VoteStep)
 	template.Description = currentROTI.GetDescription()
 	template.HasFeedback = currentROTI.HasFeedback()
+	template.RequireName = currentROTI.RequiresName()
 	template.Version = Version
 
 	if currentConfig.EnableTracing {
@@ -344,7 +346,7 @@ func postROTIHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var rotiname string
-	var hide, feedback bool
+	var hide, feedback, requireName bool
 
 	// get ROTI name from form if present. "" if not
 	if err := r.ParseForm(); err != nil {
@@ -360,7 +362,11 @@ func postROTIHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Form.Get("feedback") == "on" {
 		feedback = true
 	}
-	rotiID := model.CreateROTI(rotiname, hide, feedback, currentConfig.CleanOverTime)
+	requireName = false
+	if r.Form.Get("require_name") == "on" {
+		requireName = true
+	}
+	rotiID := model.CreateROTI(rotiname, hide, feedback, requireName, currentConfig.CleanOverTime)
 
 	http.Redirect(w, r, "/roti/"+strconv.Itoa(int(rotiID)), http.StatusSeeOther)
 }
@@ -385,6 +391,7 @@ func postVoteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	feedback := r.FormValue("feedback")
+	voterName := r.FormValue("voter_name")
 	// check vote validity
 	vote, err := model.CheckVote(r.FormValue("vote"))
 	if err != nil {
@@ -399,7 +406,7 @@ func postVoteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := currentROTI.AddVoteToROTI(vote, feedback); err != nil {
+	if err := currentROTI.AddVoteToROTI(vote, feedback, voterName); err != nil {
 		log.Warn().Err(err).Msg("")
 		http.Redirect(w, r, "/roti/"+strconv.Itoa(rotiID), http.StatusFound)
 		return

--- a/internal/services/handler_test.go
+++ b/internal/services/handler_test.go
@@ -70,7 +70,7 @@ func TestHomeHandler(t *testing.T) {
 
 func generateTestsROTIs() (existingROTI int, nonExistingROTI int) {
 	// create a roti and get the ID
-	rotiID := model.CreateROTI("test", false, false, 30)
+	rotiID := model.CreateROTI("test", false, false, false, 30)
 	existingROTI = rotiID.Int()
 
 	// then create an id from a roti that doesn't exist
@@ -138,7 +138,7 @@ func TestDisplayVoteHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := currentROTI.AddVoteToROTI(3.0, "ok"); err != nil {
+	if err := currentROTI.AddVoteToROTI(3.0, "ok", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -236,7 +236,7 @@ func TestPostVoteHandler(t *testing.T) {
 	router := http.DefaultServeMux
 	router.HandleFunc("/vote/{rotiid}", postVoteHandler)
 
-	rotiID := model.CreateROTI("test", true, true, 30)
+	rotiID := model.CreateROTI("test", true, true, false, 30)
 
 	testCases := []struct {
 		query              string

--- a/internal/staticEmbed/templates/index.html
+++ b/internal/staticEmbed/templates/index.html
@@ -36,6 +36,10 @@
                                     <input type="checkbox" id="feedback" name="feedback" checked>
                                     Enable feedback textbox
                                 </label>
+                                <label>
+                                    <input type="checkbox" id="require_name" name="require_name">
+                                    Require respondent name
+                                </label>
                             </fieldset>
                             <input type="submit" value="Create ROTI">
                         </form>

--- a/internal/staticEmbed/templates/vote.html
+++ b/internal/staticEmbed/templates/vote.html
@@ -38,6 +38,11 @@
 
                     <input type="hidden" name="vote" id="vote-value" value="">
 
+                    {{ if .RequireName}}
+                    <label for="voter_name">Your name</label>
+                    <input type="text" name="voter_name" id="voter_name" placeholder="e.g. Jane Doe" required>
+                    {{ end }}
+
                     {{ if .HasFeedback}}
                     <label for="feedback">Optional feedback</label>
                     <textarea name="feedback" id="feedback" rows="2" placeholder="What could have been improved?"></textarea>


### PR DESCRIPTION
## Description

Ajoute une fonctionnalité optionnelle pour rendre le ROTI non-anonyme : un champ **Require respondent name** dans le formulaire de création, qui affiche un champ "Your name" sur la page de vote.

## Modifications

- **DB** : nouvelles colonnes `require_name` (table `roti`) et `voter_name` (table `vote`) + migration automatique
- **Modèle** : `ROTIEntity.RequiresName()`, `AddVoteToROTI()` accepte `voterName`
- **Handler** : parse et transmet `require_name` / `voter_name`
- **Templates** : checkbox dans le formulaire de création, champ texte sur la page de vote
- **Export** : `ListFeedbacks()` affiche le nom quand présent (ex. `(4.5) John — Super session`)

## Validation

- [x] Compilation OK
- [x] Tests existants passent
- [x] Tests manuels OK
- [ ] 

<img width="1522" height="799" alt="Capture d’écran du 2026-06-06 13-39-28" src="https://github.com/user-attachments/assets/d76965e5-64aa-4a9f-901d-33024d40c155" />

<img width="1538" height="1043" alt="Capture d’écran du 2026-06-06 13-40-20" src="https://github.com/user-attachments/assets/1d9740f6-d3ca-469a-a6a9-dbe0f1d1ac86" />

 