### PR TITLE
fix: prevent selecting 0.5 as vote value (minimum is 1)

### DIFF
--- a/internal/staticEmbed/templates/vote.html
+++ b/internal/staticEmbed/templates/vote.html
@@ -137,7 +137,8 @@
 
             function onClickHalf(e, wrap, pos) {
                 const rect = wrap.getBoundingClientRect();
-                const val = (e.clientX - rect.left) < rect.width / 2 ? pos - 0.5 : pos;
+                let val = (e.clientX - rect.left) < rect.width / 2 ? pos - 0.5 : pos;
+                if (val < 1) val = 1;
                 select(val, pos);
             }
         })();


### PR DESCRIPTION
## Description

Le backend rejette correctement les votes < 1 (code 406), mais l'interface en half-step mode permettait de cliquer sur 0.5 (moitié gauche de la première étoile). Cette PR corrige en clampant la valeur minimale à 1 côté client.

## Modifications

- vote.html : dans onClickHalf, si val < 1 on le remonte à 1 avant de sélectionner