### PR TITLE
fix: prevent stored XSS in feedback rendering

### DIFF
--- a/internal/staticEmbed/templates/roti.html
+++ b/internal/staticEmbed/templates/roti.html
@@ -105,9 +105,13 @@
             document.querySelectorAll('.feedback-list li').forEach(li => {
                 const match = li.textContent.match(/^\(([^)]+)\)\s*(.*)/s);
                 if (match) {
-                    li.innerHTML =
-                        '<span class="feedback-score">★ ' + match[1] + '</span>' +
-                        '<span class="feedback-text">' + match[2] + '</span>';
+                    const score = document.createElement('span');
+                    score.className = 'feedback-score';
+                    score.textContent = '★ ' + match[1];
+                    const text = document.createElement('span');
+                    text.className = 'feedback-text';
+                    text.textContent = match[2];
+                    li.replaceChildren(score, text);
                 }
             });
         })();


### PR DESCRIPTION
## Problem

Feedback text is escaped server-side (`{{ . }}` via `html/template`), but the client script in `roti.html` undid that protection:

```js
const match = li.textContent.match(...)   // textContent = raw, un-escaped text
li.innerHTML = '...' + match[1] + ... + match[2] + ...  // re-injected without escaping
```

Reading `textContent` returns the original (un-escaped) characters, and `innerHTML` then interprets them as HTML. A feedback like `(3.5) <img src=x onerror=alert(document.cookie)>` is **stored** (no sanitization in `postVoteHandler` / `insertVote`) and executes for **every** visitor of the ROTI results page — an unauthenticated stored XSS, since anyone can POST a feedback to any existing ROTI.

## Fix

Build the badge elements with `createElement` + `textContent` + `replaceChildren` instead of `innerHTML`. The visual result is identical, but user-supplied feedback can no longer be parsed as HTML.

## Test

- Create a ROTI with feedback enabled, vote with feedback `(3.5) <img src=x onerror=alert(1)>`.
- Before: alert fires on the results page. After: the literal text is displayed.