### PR TITLE
fix: prevent CSV formula injection in export

### DIFF
--- a/internal/services/export.go
+++ b/internal/services/export.go
@@ -6,6 +6,7 @@ import (
 	"image/color"
 	"image/draw"
 	"io/fs"
+	"strings"
 
 	"github.com/deezer/groroti/internal/staticEmbed"
 	"github.com/goki/freetype/truetype"
@@ -68,7 +69,19 @@ func exportAsPNG(roti existingROTI) *image.RGBA {
 
 func exportAsCSV(roti existingROTI) (csv_strings []string) {
 	csv_strings = []string{"ROTI ID,Description,Average ROTI,Min ROTI,Max ROTI,Number of Votes",
-		fmt.Sprintf("%d,%s,%.2f,%.2f,%.2f,%d", roti.Id, roti.Description, roti.Avg, roti.Min, roti.Max, roti.NumVotes)}
+		fmt.Sprintf("%d,%s,%.2f,%.2f,%.2f,%d", roti.Id, csvSafeField(roti.Description), roti.Avg, roti.Min, roti.Max, roti.NumVotes)}
 
 	return csv_strings
+}
+
+// csvSafeField quotes a free-text field for CSV output and neutralizes
+// spreadsheet formula injection: a value starting with =, +, -, @, tab or CR
+// is prefixed with a single quote so spreadsheet apps treat it as text rather
+// than a formula. The value is also wrapped in double quotes (with internal
+// quotes doubled) so commas and newlines can't break the CSV structure.
+func csvSafeField(s string) string {
+	if s != "" && strings.ContainsRune("=+-@\t\r", rune(s[0])) {
+		s = "'" + s
+	}
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
 }


### PR DESCRIPTION
## Problem

In `exportAsCSV`, the ROTI description (free text) is written into the CSV unescaped:

```go
fmt.Sprintf("%d,%s,%.2f,%.2f,%.2f,%d", roti.Id, roti.Description, ...)
```

A description starting with `=`, `+`, `-` or `@` is interpreted as a **formula** when the CSV is opened in Excel / Google Sheets (CSV formula injection). Embedded commas or newlines can also break the CSV row structure.

Note: modern spreadsheets prompt before executing formulas from imported CSVs, so real-world impact is limited — but escaping is cheap and correct, and it also fixes the structural-corruption case.

## Fix

`csvSafeField` wraps the field in double quotes (doubling any internal quotes) and prefixes a single quote when the value starts with a formula trigger (`= + - @ \t \r`), so spreadsheets treat it as inert text.

## Test

Existing `internal/services` tests pass (`go test ./internal/services/`).
Manual: create a ROTI named `=1+1` and download the CSV — the cell now shows the literal text instead of `2`.