### PR TITLE
fix: check QR code existence at the path where it is written

### DIFF
--- a/internal/services/handler.go
+++ b/internal/services/handler.go
@@ -141,7 +141,7 @@ func displayROTIHandler(w http.ResponseWriter, r *http.Request) {
 
 	// checks if QRcode exists or not. If not, generates one
 	strID := strconv.Itoa(rotiID)
-	if _, err := os.Stat("qr/qr" + strID + ".png"); errors.Is(err, os.ErrNotExist) {
+	if _, err := os.Stat("data/qr/qr" + strID + ".png"); errors.Is(err, os.ErrNotExist) {
 		if err := genQRCode(currentConfig.GetURL(), strID, ctx); err != nil {
 			log.Warn().Err(ErrQRCodeGeneration)
 		}


### PR DESCRIPTION
## Problem

`displayROTIHandler` checks for an existing QR code with:

```go
os.Stat("qr/qr" + strID + ".png")
```

but `genQRCode` writes it to `data/qr/qr<id>.png`, and the file server also serves from `data/qr`. The stat path never matches the real location, so `errors.Is(err, os.ErrNotExist)` is always true and the QR code is **regenerated on every view** of a ROTI page.

## Fix

Stat the same path the file is actually written to (`data/qr/...`), so the QR code is generated once and reused.

## Test

Open a ROTI page twice; `data/qr/qr<id>.png` is created once and not rewritten on the second view.