### PR TITLE
fix: correct chart template bugs

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "groroti.fullname" . }}
   labels:
-    {{- include "groroti.labels" . | nindent 4 }}s
+    {{- include "groroti.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -18,11 +18,5 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-  {{- if .Values.ingress.tls }}
-    - port: {{ .Values.service.sport }}
-      targetPort: https
-      protocol: TCP
-      name: https
-  {{- end }}
   selector:
     {{- include "groroti.selectorLabels" . | nindent 4 }}

--- a/helm/templates/servicemonitor.yaml
+++ b/helm/templates/servicemonitor.yaml
@@ -17,5 +17,5 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      {{- include "groroti.labels" . | nindent 6 }}
+      {{- include "groroti.selectorLabels" . | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
Three confirmed bugs in the Helm templates (verified with `helm template` / `helm lint`).

## 1. Corrupted label on the Deployment

`templates/deployment.yaml` had a stray `s` after the labels block:

```yaml
  labels:
    {{- include "groroti.labels" . | nindent 4 }}s
```

→ rendered `app.kubernetes.io/managed-by: Helms`. Removed the `s`.

## 2. Dead `https` port on the Service

When `ingress.tls` is set (the default), the Service exposed `port: 443 → targetPort: https`, but the pod only declares the `http` (3000) named port — there is no `https` port, so it routed nowhere. TLS is terminated at the Ingress, so the port served no purpose. Removed it.

## 3. Unstable ServiceMonitor selector

The selector used the full `groroti.labels` set, which includes `helm.sh/chart` and `app.kubernetes.io/version`. A selector must use the stable subset, otherwise it stops matching after any chart version bump. Switched to `groroti.selectorLabels`.

## Validation

`helm lint` passes; `helm template` now renders `managed-by: Helm`, a single `http` service port, and a ServiceMonitor selector limited to `name` + `instance`.