### PR TITLE
chore: bump GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,30 +14,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.25'
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: '~> v2'


### PR DESCRIPTION
## Why

The v1.4.1 release run flagged the Node.js 20 deprecation: GitHub forces Node 20 actions to Node 24 from **2026-06-16** and removes the Node 20 runner on **2026-09-16**. All actions in `release.yml` currently run on Node 20.

## Change

Bump each action to its latest major — verified that every target runs on `node24` (checked `runs.using` in each `action.yml`):

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 | v6 |
| actions/setup-go | v5 | v6 |
| docker/login-action | v3 | v4 |
| docker/setup-qemu-action | v3 | v4 |
| docker/setup-buildx-action | v3 | v4 |
| goreleaser/goreleaser-action | v6 | v7 |

No workflow logic changes; inputs are unchanged (goreleaser still pinned to `~> v2`).

## Validation

The workflow only runs on tag push, so it will be exercised by the next release tag. Nothing else consumes these actions.